### PR TITLE
Refactor invalid flag handling to be more idiomatic.

### DIFF
--- a/goe.go
+++ b/goe.go
@@ -48,7 +48,6 @@ func usage() {
 	fmt.Fprintln(os.Stderr, `Usage: goe [flags] [packages] [package.]function(parameters)
        echo parameters | goe --stdin [flags] [packages] [package.]function`)
 	flag.PrintDefaults()
-	os.Exit(2)
 }
 
 var quietFlag = flag.Bool("quiet", false, "Do not dump the return values as a goon.")
@@ -60,7 +59,8 @@ func main() {
 	flag.Parse()
 
 	if flag.NArg() < 1 {
-		usage()
+		flag.Usage()
+		os.Exit(2)
 		return
 	}
 


### PR DESCRIPTION
- Remove os.Exit call from usage func.

According to https://github.com/golang/tools/commit/92211c448d04f8672d287e7ef3272d5e86abadbc, this seems to be a more idiomatic style.

Behavior should be unchanged, since internal callers of usage func already do `os.Exit(2)` when there are flag parsing errors.