### PR TITLE
Revert temporary solution to avoid stale builds, unneeded in Go 1.5.

### DIFF
--- a/goe.go
+++ b/goe.go
@@ -37,7 +37,7 @@ func run(src string) error {
 	}
 
 	// Compile and run the program.
-	cmd := exec.Command("go", "run", "-a", tempFile)
+	cmd := exec.Command("go", "run", tempFile)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This change depends on Go 1.5 being used, and should be merged after Go 1.5 is released.

In Go 1.5, a longstanding issue golang/go#10509 has been finally resolved!

Since the generated .go file resides somewhere in a temporary folder, it was outside the GOPATH boundary, and if a package is built but stale (i.e. source code has been changed since it was built), the stale version would've been used.

This reverts a temporary inefficient solution (95bb2b3351332669e3cd3d52a74e69e01ca3e623) of rebuilding absolutely all packages at all times just to avoid the risk of incorrectly building with a stale package.

Resolves #3.